### PR TITLE
Update initializer to be Ember.js 2.1.x compliant.

### DIFF
--- a/app/initializers/ember-cli-build-timestamp.js
+++ b/app/initializers/ember-cli-build-timestamp.js
@@ -1,7 +1,7 @@
 export default {
   name: 'buildTimestamp',
 
-  initialize: function (container, application) {
+  initialize: function (application) {
     var timestamp = application.BUILD_TIMESTAMP;
     var key = 'buildTimestamp';
 


### PR DESCRIPTION
Since 2.1.x the `initializer` get strictly 1(!) argument (`Ember.ApplicationInstance`) --> see http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container

Previously, the following deprecation message was raised when using `ember-cli-build-timestamp` with Ember 2.1.x

> The `initialize` method for Application initializer 'buildTimestamp' should take only one argument - `App`, an instance of an `Application`. [deprecation id: ember-application.app-initializer-initialize-arguments] See http://emberjs.com/deprecations/v2.x/#toc_initializer-arity for more details.
